### PR TITLE
benchstat: accept io.Writer in FormatHTML, not *bytes.Buffer

### DIFF
--- a/benchstat/html.go
+++ b/benchstat/html.go
@@ -5,8 +5,8 @@
 package benchstat
 
 import (
-	"bytes"
 	"html/template"
+	"io"
 	"strings"
 )
 
@@ -75,12 +75,7 @@ func htmlGroup(rows []*Row) (out [][]*Row) {
 	return
 }
 
-// FormatHTML appends an HTML formatting of the tables to buf.
-func FormatHTML(buf *bytes.Buffer, tables []*Table) {
-	err := htmlTemplate.Execute(buf, tables)
-	if err != nil {
-		// Only possible errors here are template not matching data structure.
-		// Don't make caller check - it's our fault.
-		panic(err)
-	}
+// FormatHTML appends an HTML formatting of the tables to w.
+func FormatHTML(w io.Writer, tables []*Table) {
+	must(htmlTemplate.Execute(w, tables))
 }


### PR DESCRIPTION
This brings the API in-line with that of `FormatText` and `FormatCSV` and
allows it to be used without necessitating an intermediate buffer. The
change is fully backwards compatible and doesn't impose any potential
performance cost because `html.Template.Execute` accepts an `io.Writer`,
so any `bytes.Buffer` passed by reference to FormatHTML was already
being forced to escape onto the heap.

This might have been done this way to avoid questions about how the
function should handle errors from Writer, but we already ignore those
questions and panic in `FormatCSV`, so it seems reasonable that we would
do the same thing here.