### PR TITLE
benchfmt: return an error in case of a non UTF-8 encoded file

### DIFF
--- a/benchfmt/reader.go
+++ b/benchfmt/reader.go
@@ -149,6 +149,11 @@ func (r *Reader) Scan() bool {
 		r.result.line++
 		// We do everything in byte buffers to avoid allocation.
 		line := r.s.Bytes()
+		// We only accept utf-8 encoded files.
+		if !utf8.Valid(line) {
+			r.err = fmt.Errorf("%s: invalid encode, only utf-8 encoded files are supported", r.result.fileName)
+			return false
+		}
 		// Most lines are benchmark lines, and we can check
 		// for that very quickly, so start with that.
 		if bytes.HasPrefix(line, benchmarkPrefix) {


### PR DESCRIPTION
Currently, when using the benchstat tool to read files that are not UTF-8 encoded, it will fail silently. With this patch, when parsing non UTF-8 encoded files, benchfmt will now return an error instead letting the user know their input file is not properly formatted.

Fixes https://github.com/golang/go/issues/58579